### PR TITLE
add restart button

### DIFF
--- a/gui/latency_gui.py
+++ b/gui/latency_gui.py
@@ -228,7 +228,14 @@ class LatencyGUI(QtWidgets.QWizard):
         if int(line_id) == Constants.NUM_TEST_ITERATIONS:
             self.ui.label_press_button_again.setText('Measurement finished. Analysing and saving data...')
 
+    def reset_page_three(self):
+        self.ui.label_press_button_again.setText("Press the button of your device one more time to start the measurement")
+        self.ui.progressBar.setValue(0)
+        self.ui.label_progress.setText("0/100")
+        self.ui.label_last_measured_time.setText("0.0ms")
+
     def thread_finished(self):
+        self.reset_page_three()
         print('Thread finished')
 
     @pyqtSlot('QString')
@@ -260,20 +267,21 @@ class LatencyGUI(QtWidgets.QWizard):
 
     # User interface for page five (Page that askes the user if he wants to upload the measurements)
     def init_ui_page_five(self):
-        self.ui.setButtonText(QtWidgets.QWizard.NextButton, 'Continue to Upload Results')
+        self.ui.setButtonText(QtWidgets.QWizard.NextButton, 'Upload Results')
         self.ui.button(QtWidgets.QWizard.NextButton).clicked.disconnect(self.init_ui_page_five)
         self.ui.button(QtWidgets.QWizard.NextButton).clicked.connect(self.init_ui_page_six)
 
-        self.ui.setButtonText(QtWidgets.QWizard.CancelButton, 'Exit application without uploading results')
+        self.ui.setButtonText(QtWidgets.QWizard.CancelButton, 'Exit without uploading')
 
         #TODO: Add custom button to restart the application to conduct a new measurement
-        #self.setOption(QtWidgets.QWizard.HaveCustomButton1, True)
-        #self.ui.setButtonText(QtWidgets.QWizard.CustomButton1, 'Start a new measurement without uploading results')
-        #self.button(QtWidgets.QWizard.CustomButton1).clicked.connect(self.restart_application)
+        self.setOption(QtWidgets.QWizard.HaveCustomButton1, True)
+        self.ui.setButtonText(QtWidgets.QWizard.CustomButton1, 'Restart without uploading')
+        self.button(QtWidgets.QWizard.CustomButton1).clicked.connect(self.restart_application)
 
     def restart_application(self):
         self.ui.button(QtWidgets.QWizard.NextButton).clicked.disconnect(self.init_ui_page_six)
         self.setOption(QtWidgets.QWizard.HaveCustomButton1, False)
+        self.reset_all_data()
         self.init_ui_page_one()
         QtWidgets.QWizard.restart(self)
 

--- a/gui/latency_gui.py
+++ b/gui/latency_gui.py
@@ -19,8 +19,6 @@ import configparser
 
 import DataPlotter  # Accepts a .csv file of a LagBox measurement and returns a dataplot and statistical data
 
-import RPi.GPIO as GPIO
-
 
 class Constants:
     UI_FILE = 'latency_gui_800x480.ui'
@@ -41,7 +39,7 @@ class Constants:
 
     TEXT_INPUT_MAX_CHARS = 64  # Max number of chars of the input fields
 
-    GPIO_PIN_ID = 7  # ID of the GPIO Pin where the optocoupler is connected to the Raspberry Pi
+    GPIO_PIN_ID = 21  # ID of the GPIO Pin where the optocoupler is connected to the Raspberry Pi
 
 
 class LatencyGUI(QtWidgets.QWizard):
@@ -70,15 +68,10 @@ class LatencyGUI(QtWidgets.QWizard):
 
     def __init__(self):
         super().__init__()
-        self.reset_gpio_pins()
         self.init_ui()
 
     # Make sure that the GPIO pin where the raspberry Pi is connected to the optocoupler is set to LOW on startup
     # Otherwise this could cause unwanted button presses.
-    def reset_gpio_pins(self):
-        GPIO.setmode(GPIO.BCM)
-        GPIO.setup(Constants.GPIO_PIN_ID, GPIO.OUT)
-        GPIO.output(Constants.GPIO_PIN_ID, GPIO.LOW)
 
     def init_ui(self):
         self.ui = uic.loadUi(Constants.UI_FILE, self)

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,10 +3,10 @@ CFLAGS=-Wall
 
 main: inputLatencyMeasureTool.c
 	-mkdir ../bin
-	$(CC) -Wall -c inputLatencyMeasureTool.c -lwiringPi -lrt -o ../bin/inputLatencyMeasureTool.o -std=gnu99
+	$(CC) -Wall -c inputLatencyMeasureTool.c -lgpiod  -lrt -o ../bin/inputLatencyMeasureTool.o -std=gnu99
 	$(CC) -Wall -c joystickControl.c -o ../bin/joystickControl.o -std=c99
 	$(CC) -Wall -c fileLog.c -o ../bin/fileLog.o -std=c99
-	$(CC) ../bin/inputLatencyMeasureTool.o ../bin/joystickControl.o ../bin/fileLog.o -lm -lwiringPi -lrt -lpthread -o ../bin/inputLatencyMeasureTool
+	$(CC) ../bin/inputLatencyMeasureTool.o ../bin/joystickControl.o ../bin/fileLog.o -lm -lgpiod -lrt -lpthread -o ../bin/inputLatencyMeasureTool
 
 clean:
 	-rm -rf ../bin

--- a/src/inputLatencyMeasureTool.c
+++ b/src/inputLatencyMeasureTool.c
@@ -104,7 +104,7 @@ void autoMode(struct AutoModeData *results, unsigned int iterations)
 	for (int i = 0; i < iterations; i++)
 	{
 		debug("iteration %d \n", i);
-		gpiod_line_set_value(PIN_AUTO_MODE, 0);
+		gpiod_line_set_value(lineAutoMode, 0);
 		
 
 		while (1)
@@ -122,7 +122,7 @@ void autoMode(struct AutoModeData *results, unsigned int iterations)
 		usleep(delayList[i]);
 
 		dStartTime = getCurTime_microseconds(CLOCK_REALTIME); 
-		gpiod_line_set_value(PIN_AUTO_MODE, 1);
+		gpiod_line_set_value(lineAutoMode, 1);
 
 		while (1)
 		{
@@ -140,7 +140,7 @@ void autoMode(struct AutoModeData *results, unsigned int iterations)
 
 				results[i] = data;
 
-				//gpiod_line_set_value(PIN_AUTO_MODE, 0);; //clear pin
+				//gpiod_line_set_value(lineAutoMode, 0); //clear pin
 				break;
 			}
 
@@ -154,7 +154,7 @@ void autoMode(struct AutoModeData *results, unsigned int iterations)
 		usleep(10);
 	}
 
-	gpiod_line_set_value(PIN_AUTO_MODE, 0);
+	gpiod_line_set_value(lineAutoMode, 0);
 }
 
 int checkButtonState(long long* timestamp)
@@ -260,9 +260,9 @@ void testPin(int pin)
 {
 	for(int i = 0; i < 1000; i++)
 	{
-		gpiod_line_set_value(pin, 1);
+		gpiod_line_set_value(lineAutoMode, 1);
 		usleep(1000000);
-		gpiod_line_set_value(pin, 0);
+		gpiod_line_set_value(lineAutoMode, 0);
 		usleep(1000000);
 	}
 }
@@ -272,8 +272,8 @@ void setupPins()
 	debug("setting up pins...\n");
 
 	lineAutoMode = gpiod_chip_get_line(chip, PIN_AUTO_MODE);
-	gpiod_line_request_output(PIN_AUTO_MODE, "foo", 0);
-	gpiod_line_set_value(PIN_AUTO_MODE, 1);
+	gpiod_line_request_output(lineAutoMode, "foo", 0);
+	gpiod_line_set_value(lineAutoMode, 1);
 }
 
 // swap array elements
@@ -335,9 +335,9 @@ void debug(const char* format, ...)
 
 int main(int argc, char *argv[])
 {
+	printf("foo");
 	srand(time(NULL));
 
-	// wiringPiSetup();
   	// Open GPIO chip
   	chip = gpiod_chip_open_by_name(chipname);
 

--- a/src/inputLatencyMeasureTool.h
+++ b/src/inputLatencyMeasureTool.h
@@ -19,7 +19,7 @@
 #define CHANNEL_BUTTON_RIGHT 4
 #define SPI_CHANNEL 0
 
-#define PIN_AUTO_MODE 11 //pin used for auto-mode
+#define PIN_AUTO_MODE 21 //pin used for auto-mode
 #define POLARITY_THRESHOLD 500 //Threshold for checking the logic of a game-pad
 
 #define	AF_BASE		100

--- a/src/inputLatencyMeasureTool.h
+++ b/src/inputLatencyMeasureTool.h
@@ -2,6 +2,8 @@
 #define inputLatencyMeasureTool_h__
 
 #include <pthread.h>
+#include <gpiod.h>
+
 
 // Defines
 // MCP Params

--- a/src/joystickControl.h
+++ b/src/joystickControl.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <linux/joystick.h>


### PR DESCRIPTION
added a button to restart the measuring process and return to page one on page five (the one where the user is asked to upload their measurements)
shortened the button texts for page five for that, so all the text fits on the prototype's small display.